### PR TITLE
重构 useEffect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,7 @@ Fix: Pass null to useState should not cause rerender.
 # 1.4.4
 
 Fix: clean stashedContext after unmount.
+
+# 1.4.5
+
+Fix: fixed a problem which effect forgot cleanup after recreate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Fix: Pass null to useState should not cause rerender.
 
 Fix: clean stashedContext after unmount.
 
-# 1.4.5
+# 1.5.0
 
 Fix: fixed a problem which effect forgot cleanup after recreate.
+Removal: remove `useAsyncEffect`.

--- a/lib/src/hook.dart
+++ b/lib/src/hook.dart
@@ -29,6 +29,8 @@ class _Effect {
   _Effect({this.needUpdate = false, this.create, this.deps, this.destroy});
 }
 
+class _HookTypeError extends Error {}
+
 _Hook _workInProgressHook;
 HookElement _stashedContext;
 

--- a/lib/src/hook.dart
+++ b/lib/src/hook.dart
@@ -14,22 +14,32 @@ part 'useAnimationController.dart';
 part 'hook_widget.dart';
 part 'hook_element.dart';
 
-class Hook {
+class _Hook {
   dynamic memorizedState;
-  Hook next;
+  _Hook next;
 }
 
-Hook _workInProgressHook;
+class _Effect {
+  bool needUpdate;
+  Function() create;
+  List<dynamic> deps;
+  VoidCallback destroy;
+  _Effect next;
+
+  _Effect({this.needUpdate = false, this.create, this.deps, this.destroy});
+}
+
+_Hook _workInProgressHook;
 HookElement _stashedContext;
 
-Hook _createWorkInProgressHook() {
+_Hook _createWorkInProgressHook() {
   final currentContext = _stashedContext;
 
   if (_workInProgressHook == null) {
     _workInProgressHook = currentContext.hook;
   } else {
     if (_workInProgressHook.next == null) {
-      _workInProgressHook = _workInProgressHook.next = Hook();
+      _workInProgressHook = _workInProgressHook.next = _Hook();
     } else {
       _workInProgressHook = _workInProgressHook.next;
     }

--- a/lib/src/hook_element.dart
+++ b/lib/src/hook_element.dart
@@ -37,34 +37,40 @@ class HookElement extends StatelessElement {
 
   /// cause of [mount] called before [build]. So create a method [didBuild] for react like didUpdate.
   void didBuild(Duration duration) {
-    var effect = lastEffect;
-    do {
-      if (effect.needUpdate) {
-        effect?.destroy?.call();
-        var destroy = effect.create();
-        if (destroy is Function) {
-          effect.destroy = destroy;
-        } else {
-          if (destroy is Future) {
-            throw FlutterError(
-                'It looks like you wrote useEffect(async () => ...) or returned a Promise.');
-          }
+    if (lastEffect != null) {
+      var effect = lastEffect;
+      do {
+        if (effect.needUpdate) {
+          effect?.destroy?.call();
+          var destroy = effect.create();
+          if (destroy != null) {
+            if (destroy is Function) {
+              effect.destroy = destroy;
+            } else {
+              if (destroy is Future) {
+                throw FlutterError(
+                    'It looks like you wrote useEffect(async () => ...) or returned a Promise.');
+              }
 
-          throw FlutterError(
-              'An effect function must not return anything besides a function, which is used for clean-up.');
+              throw FlutterError(
+                  'An effect function must not return anything besides a function, which is used for clean-up.');
+            }
+          }
         }
-      }
-    } while ((effect = lastEffect?.next) != null);
+      } while ((effect = lastEffect?.next) != null);
+    }
   }
 
   @override
   void unmount() {
     _stashedContext = null;
     _workInProgressHook = null;
-    var effect = lastEffect;
-    do {
-      effect?.destroy?.call();
-    } while ((effect = lastEffect?.next) != null);
+    if (lastEffect != null) {
+      var effect = lastEffect;
+      do {
+        effect?.destroy?.call();
+      } while ((effect = lastEffect?.next) != null);
+    }
     super.unmount();
   }
 }

--- a/lib/src/hook_element.dart
+++ b/lib/src/hook_element.dart
@@ -1,7 +1,5 @@
 part of './hook.dart';
 
-class _HookTypeError extends Error {}
-
 class HookElement extends StatelessElement {
   _Hook hook = _Hook();
   _Effect lastEffect;

--- a/lib/src/useEffect.dart
+++ b/lib/src/useEffect.dart
@@ -6,14 +6,14 @@ useEffect(void Function() Function() effectCallback, [List<dynamic> deps]) {
 
   if (_workInProgressHook.memorizedState == null) {
     _workInProgressHook.memorizedState = deps;
-    currentContext.updatePhaseEffectQueue.add(effectCallback);
+    currentContext.effectQueue.add(effectCallback);
   } else {
     var prevDeps = _workInProgressHook.memorizedState;
 
     // if dependencies changed, should memorize changed dependencies.
     if (!areHookInputsEqual(prevDeps, deps)) {
       _workInProgressHook.memorizedState = deps;
-      currentContext.updatePhaseEffectQueue.add(effectCallback);
+      currentContext.effectQueue.add(effectCallback);
     }
   }
 }
@@ -25,13 +25,13 @@ useAsyncEffect(Future<void Function()> Function() effectCallback,
 
   if (_workInProgressHook.memorizedState == null) {
     _workInProgressHook.memorizedState = deps;
-    currentContext.updatePhaseEffectQueue.add(effectCallback);
+    currentContext.effectQueue.add(effectCallback);
   } else {
     var prevDeps = _workInProgressHook.memorizedState;
 
     if (!areHookInputsEqual(prevDeps, deps)) {
       _workInProgressHook.memorizedState = deps;
-      currentContext.updatePhaseEffectQueue.add(effectCallback);
+      currentContext.effectQueue.add(effectCallback);
     }
   }
 }

--- a/lib/src/useEffect.dart
+++ b/lib/src/useEffect.dart
@@ -1,37 +1,26 @@
 part of 'hook.dart';
 
-useEffect(void Function() Function() effectCallback, [List<dynamic> deps]) {
+_Effect _pushEffect(needUpdate, create, deps, destroy) {
   var currentContext = _stashedContext;
-  _workInProgressHook = _createWorkInProgressHook();
-
-  if (_workInProgressHook.memorizedState == null) {
-    _workInProgressHook.memorizedState = deps;
-    currentContext.effectQueue.add(effectCallback);
+  var effect = _Effect(
+      needUpdate: needUpdate, destroy: destroy, create: create, deps: deps);
+  if (currentContext.lastEffect == null) {
+    currentContext.lastEffect = effect;
   } else {
-    var prevDeps = _workInProgressHook.memorizedState;
-
-    // if dependencies changed, should memorize changed dependencies.
-    if (!areHookInputsEqual(prevDeps, deps)) {
-      _workInProgressHook.memorizedState = deps;
-      currentContext.effectQueue.add(effectCallback);
-    }
+    currentContext.lastEffect = currentContext.lastEffect.next = effect;
   }
+  return effect;
 }
 
-useAsyncEffect(Future<void Function()> Function() effectCallback,
-    [List<dynamic> deps]) {
-  var currentContext = _stashedContext;
+useEffect(Function() create, [List<dynamic> deps]) {
   _workInProgressHook = _createWorkInProgressHook();
 
-  if (_workInProgressHook.memorizedState == null) {
-    _workInProgressHook.memorizedState = deps;
-    currentContext.effectQueue.add(effectCallback);
-  } else {
-    var prevDeps = _workInProgressHook.memorizedState;
+  _Effect prevEffects = _workInProgressHook.memorizedState;
 
-    if (!areHookInputsEqual(prevDeps, deps)) {
-      _workInProgressHook.memorizedState = deps;
-      currentContext.effectQueue.add(effectCallback);
-    }
+  if (areHookInputsEqual(prevEffects?.deps, deps)) {
+    _pushEffect(false, create, deps, prevEffects?.destroy);
+  } else {
+    _workInProgressHook.memorizedState =
+        _pushEffect(true, create, deps, prevEffects?.destroy);
   }
 }

--- a/lib/src/useMemo.dart
+++ b/lib/src/useMemo.dart
@@ -1,11 +1,11 @@
 part of 'hook.dart';
 
-T useMemo<T>(T Function() returnMemorizedState, [List<dynamic> deps]) {
+T useMemo<T>(T Function() create, [List<dynamic> deps]) {
   _workInProgressHook = _createWorkInProgressHook();
 
   if (_workInProgressHook.memorizedState == null) {
     _workInProgressHook.memorizedState = {
-      "state": returnMemorizedState(),
+      "state": create(),
       "deps": deps
     };
   } else {
@@ -14,7 +14,7 @@ T useMemo<T>(T Function() returnMemorizedState, [List<dynamic> deps]) {
     if (memorizedState is Map && memorizedState["state"] is T) {
       if (!areHookInputsEqual(memorizedState["deps"], deps)) {
         _workInProgressHook.memorizedState = {
-          "state": returnMemorizedState(),
+          "state": create(),
           "deps": deps
         };
       }

--- a/lib/src/useRef.dart
+++ b/lib/src/useRef.dart
@@ -6,7 +6,7 @@ class RefContainer<T> {
 }
 
 RefContainer<T> useRef<T>([T initialValue]) {
-  final refStateContainer = useState(RefContainer(initialValue));
+  final stateContainerRef = useState(RefContainer(initialValue));
 
-  return refStateContainer.state;
+  return stateContainerRef.state;
 }

--- a/lib/src/useState.dart
+++ b/lib/src/useState.dart
@@ -22,7 +22,7 @@ StateContainer<T> useState<T>(T initialState) {
         initialState, _genSetState(_stashedContext, _workInProgressHook));
   }
 
-  /// Due to Dart allow assign [null] to [T], so null is T should be true.
+  /// Due to Dart allow assign [null] to [T], so ([null] is [T]) should be [true].
   /// However it's false, so if [initialState] is [null], should return null,
   /// rather than throw [_HookTypeError].
   if (_workInProgressHook.memorizedState is StateContainer &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: frhooks
 description: Use react hooks in flutter!
-version: 1.4.5
+version: 1.5.0
 homepage: https://github.com/huangbinjie/frhooks
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: frhooks
-description: use react like hooks in flutter!
-version: 1.4.4
+description: Use react hooks in flutter!
+version: 1.4.5
 homepage: https://github.com/huangbinjie/frhooks
 
 environment:

--- a/test/use_effect_test.dart
+++ b/test/use_effect_test.dart
@@ -74,27 +74,6 @@ void main() {
     expect(effectResult, 1);
   });
 
-  testWidgets('remove effect', (tester) async {
-    int effectResult = 0;
-
-    await tester.pumpWidget(HookBuilder(
-      builder: () {
-        useEffect(() {
-          effectResult = 1;
-          return () {
-            effectResult = 2;
-          };
-        });
-        return Container();
-      },
-    ));
-
-    expect(effectResult, 1);
-
-    await tester.pumpWidget(SizedBox());
-
-    expect(effectResult, 2);
-  });
   testWidgets('effect should called after setState', (tester) async {
     StateContainer<int> stateContainer;
     int effectResult = 0;
@@ -120,7 +99,7 @@ void main() {
     await tester.pump();
 
     expect(stateContainer.state, 1);
-    expect(effectResult, 2);
+    expect(effectResult, 1);
 
     await tester.pumpWidget(SizedBox());
 

--- a/test/use_effect_test.dart
+++ b/test/use_effect_test.dart
@@ -24,31 +24,6 @@ void main() {
     expect(effectResult, 1);
   });
 
-  testWidgets("useEffect should momorize deps if changed", (tester) async {
-    StateContainer<int> counter;
-    HookElement context;
-    await tester.pumpWidget(HookBuilder(
-      builder: () {
-        context = useContext();
-        counter = useState(0);
-
-        useEffect(() {}, [counter.state]);
-        return Container();
-      },
-    ));
-
-    // useState { next : useEffect {}}
-    expect(context.hook.memorizedState.state, 0);
-    expect(context.hook.next.memorizedState[0], 0);
-
-    counter.setState(1);
-
-    await tester.pump();
-
-    expect(context.hook.memorizedState.state, 1);
-    expect(context.hook.next.memorizedState[0], 1);
-  });
-
   testWidgets('useDidmount', (tester) async {
     StateContainer stateContainer;
     int effectResult = 0;
@@ -104,20 +79,5 @@ void main() {
     await tester.pumpWidget(SizedBox());
 
     expect(effectResult, 0);
-  });
-
-  testWidgets('useAsyncEffect basic', (tester) async {
-    int effectResult = 0;
-
-    await tester.pumpWidget(HookBuilder(
-      builder: () {
-        useAsyncEffect(() async {
-          effectResult = await Future.value(1);
-        });
-        return Container();
-      },
-    ));
-
-    expect(effectResult, 1);
   });
 }


### PR DESCRIPTION
之前的版本 useEffect 是 build 之后运行 effect 并收集清理函数放到 `unmount` 再统一清理。

这个 pr 改成重新创建的时候先清理再创建。